### PR TITLE
Error messages

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
             // Display a warning notification if no Api token has been set
             if (!(config.get("api.token"))) {
                 const instructionsButton = "Instructions";
-                vscode.window.showWarningMessage("You have not yet configured your Dodona Api token. To correctly set up your Visual Studio Code, click the Instructions button below.", instructionsButton)
+                vscode.window.showErrorMessage("You have not yet configured your Dodona Api token. To correctly set up your Visual Studio Code, click the Instructions button below.", instructionsButton)
                 .then(selection => {
                     // Open the page when the user clicks the button
                     if (selection === instructionsButton) {


### PR DESCRIPTION
Not adding an exercise link when submitting now displays an error message (with retry button) instead of `AttributeError - ...`. Also changed the previous warning message to an error message.