### PR TITLE
Catch errors, add second api token

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,16 @@
     "configuration": {
       "title": "Dodona",
       "properties": {
-        "dodona.api.token": {
+        "dodona.api.token.dodona": {
           "type": "string",
           "default": null,
           "description": "Specifies which API token should be used to authorize to Dodona.",
+          "scope": "application"
+        },
+        "dodona.api.token.naos": {
+          "type": "string",
+          "default": null,
+          "description": "Specifies which API token should be used to authorize to Naos.",
           "scope": "application"
         },
         "dodona.api.host": {

--- a/src/exercise/identification.ts
+++ b/src/exercise/identification.ts
@@ -7,6 +7,7 @@ export interface IdentificationData {
     activity: number;
     course: number | null;
     series: number | null;
+    platform: string;
 }
 
 // Initialise regexes.
@@ -39,6 +40,10 @@ function identifySeries(url: string): number | null {
     return null;
 }
 
+function identifyPlatform(url: string) {
+    return url.toLowerCase().includes("dodona") ? "dodona" : "naos";
+}
+
 /**
  * Identifies the activity from the code.
  *
@@ -52,7 +57,13 @@ export function identify(code: string): IdentificationData {
     const activity = identifyActivity(firstLine);
     const course = identifyCourse(firstLine);
     const series = identifySeries(firstLine);
+    const platform = identifyPlatform(firstLine);
 
     // Format the result.
-    return { activity: activity, course: course, series: series };
+    return {
+        activity: activity,
+        course: course,
+        series: series,
+        platform: platform,
+    };
 }


### PR DESCRIPTION
Instead of bombarding the user with 401 errors, catch them & show a dialogue telling the user what to do in order to fix them.

Also added a second api token field to add a separate token for Dodona & Naos.

Contains code that was already changed (`platform` -> `api.host`) on `config` branch