### PR TITLE
Config show description

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "dodona.automaticallyOpenExerciseDescription": {
           "type": "boolean",
           "default": true,
-          "description": "Specifies whether or not creating a new exercise should automatically open it's description in a new window."
+          "description": "Specifies whether or not creating a new exercise should automatically open its description in a new window."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
           ],
           "description": "Specifies which Dodona environment should be used.",
           "scope": "application"
+        },
+        "dodona.automaticallyOpenExerciseDescription": {
+          "type": "boolean",
+          "default": true,
+          "description": "Specifies whether or not creating a new exercise should automatically open it's description in a new window."
         }
       }
     },

--- a/src/commands/createNewExercise.ts
+++ b/src/commands/createNewExercise.ts
@@ -23,7 +23,7 @@ export async function createNewExercise(exerciseDataClass: ExerciseDataClass) {
     }
 
     // Create a new file.
-    const fileName = `${exercise.name}.${exercise.programming_language?.extension || "txt"}`
+    const fileName = `${exercise.name}.${exercise.programming_language?.extension || "txt"}`;
     const newFile = Uri.parse("untitled:" + path.join(workspace.rootPath, `${fileName}`));
 
     // Open the created file.
@@ -36,9 +36,9 @@ export async function createNewExercise(exerciseDataClass: ExerciseDataClass) {
 
         // If the document is not empty, clear it
         if (document.getText()) {
-            const message = `File ${fileName} already exists, and is not empty. Clicking "Confirm" will clear this document's contents, and replace it with the exercise's URL & boilerplate. Any changes made will be lost. Are you sure you want to continue?`
+            const message = `File ${fileName} already exists, and is not empty. Clicking "Confirm" will clear this document's contents, and replace it with the exercise's URL & boilerplate. Any changes made will be lost. Are you sure you want to continue?`;
             const confirm = "Confirm";
-            const decline = "Decline"
+            const decline = "Decline";
 
             // Show a warning message asking for confirmation so the user doesn't
             // accidentally erase their file
@@ -57,13 +57,13 @@ export async function createNewExercise(exerciseDataClass: ExerciseDataClass) {
 
                         // Add the URL & boilerplate
                         edit.insert(newFile, new vscode.Position(0, 0), `${commentedUrl}\n${boilerplate}`);
-                        return applyEdit(edit, document);
+                        return applyEdit(edit);
                     }
             });
         } else {
             // Add the URL & boilerplate
             edit.insert(newFile, new vscode.Position(0, 0), `${commentedUrl}\n${boilerplate}`);
-            return applyEdit(edit, document);
+            return applyEdit(edit);
         }
     });
 
@@ -73,7 +73,7 @@ export async function createNewExercise(exerciseDataClass: ExerciseDataClass) {
     }
 }
 
-export async function applyEdit(edit: vscode.WorkspaceEdit, document: vscode.TextDocument) {
+export async function applyEdit(edit: vscode.WorkspaceEdit) {
     // Insert the contents into the file.
     return workspace.applyEdit(edit).then(success => {
         if (!(success)) {

--- a/src/commands/createNewExercise.ts
+++ b/src/commands/createNewExercise.ts
@@ -4,6 +4,8 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { getSyntax } from "../commentSyntax";
 import { ExerciseDataClass } from "../treeView/dataClasses";
+import { getAutoDescription } from "../configuration";
+import { showExerciseDescription } from ".././commands/showExerciseDescription";
 
 /**
  * Action to create a new file for an exercise.
@@ -25,6 +27,8 @@ export async function createNewExercise(exerciseDataClass: ExerciseDataClass) {
 
     // Open the created file.
     workspace.openTextDocument(newFile).then(document => {
+        // TODO check file content first
+
         // Build the file contents: the comment line and exercise boilerplate.
         const edit = new vscode.WorkspaceEdit();
         const commentedUrl = getSyntax(exercise.programming_language, exercise.url);
@@ -40,4 +44,9 @@ export async function createNewExercise(exerciseDataClass: ExerciseDataClass) {
             }
         });
     });
+
+    // Open the exercise if the user checked this option in the configuration
+    if (getAutoDescription()) {
+        showExerciseDescription(exerciseDataClass);
+    }
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -44,6 +44,6 @@ export function getApiToken(): ApiToken | null {
  * 
  * @return the current value of the checkbox
  */
-export function getAutoDescription(): boolean | null {
-    return config().get("automaticallyOpenExerciseDescription") || null;
+export function getAutoDescription(): boolean {
+    return config().get("automaticallyOpenExerciseDescription") || true;
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -38,3 +38,12 @@ export function getApiToken(): ApiToken | null {
     const environment = getApiEnvironment().toLowerCase();
     return config().get<string>(`auth.${environment}`) || null;
 }
+
+/**
+ * Gets the Auto-Open-Description checkbox from the configuration.
+ * 
+ * @return the current value of the checkbox
+ */
+export function getAutoDescription(): boolean | null {
+    return config().get("automaticallyOpenExerciseDescription") || null;
+}


### PR DESCRIPTION
Added a config option to automatically open the description when creating a new exercise, fixed a bug that spams exercise's URL & boilerplate when the file already existed