### PR TITLE
Fix bugs introduced yesterday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.5.2 - March 8, 2021
+* [Stijn De Clercq (@stijndcl)](https://github.com/stijndcl)
+  * [BUG] Open exercise descriptions in the right column [#98](https://github.com/thepieterdc/dodona-plugin-vscode/issues/98)
+  * [BUG] Open exercise descriptions when file name was duplicate [#97](https://github.com/thepieterdc/dodona-plugin-vscode/issues/97)
+  * [BUG] First line of boilerplate is commented along with the URL
+
 ## 1.5.1 - March 7, 2021
 * [Pieter De Clercq (@thepieterdc)](https://github.com/thepieterdc)
   * [BUG] Support duplicate exercise names [#93](https://github.com/thepieterdc/dodona-plugin-vscode/issues/93)

--- a/src/commands/createNewExercise.ts
+++ b/src/commands/createNewExercise.ts
@@ -31,7 +31,8 @@ export async function createNewExercise(exercise: Exercise) {
         if (identification && identification.activity === exercise.id) {
             // Exercise already exists, open it.
             const document = await workspace.openTextDocument(filePath);
-            window.showTextDocument(document);
+            await window.showTextDocument(document, ViewColumn.One);
+            showActivityDescription(exercise);
             return;
         }
 
@@ -56,12 +57,12 @@ export async function createNewExercise(exercise: Exercise) {
     const boilerplate = exercise.boilerplate || "";
 
     // Write the file contents.
-    const contents = `${commentedUrl}${boilerplate}\n`;
+    const contents = `${commentedUrl}\n\n${boilerplate}\n`;
     fs.writeFileSync(filePath, contents);
 
     // Open the file in the editor.
     const document = await workspace.openTextDocument(Uri.file(filePath));
-    window.showTextDocument(document, { viewColumn: ViewColumn.One });
+    await window.showTextDocument(document, { viewColumn: ViewColumn.One });
 
     // Open the description of the exercise if configured.
     if (getAutoDescription()) {

--- a/src/commands/showActivityDescription.ts
+++ b/src/commands/showActivityDescription.ts
@@ -42,6 +42,7 @@ async function openActivityDescription(
         viewColumn,
         { enableScripts: true },
     );
+
     descriptionPanels.push(panel);
 
     // Load the activity description HTML.


### PR DESCRIPTION
- Open activities in the right column | fixes #98 

This was caused by not ``await``ing ``showTextDocument``, which results in ``ViewColumn.Two`` opening in the first column (as nothing is present yet when opening the description (async), so "Two" doesn't exist, so it defaults to One)

- Open the description when a file with the same name already exists | fixes #97 

Caused by a forgotten call to `showDescription()`

- Fix bug where the first line of the boilerplate is commented as well

Caused by missing `\n` in the comment format string