### PR TITLE
Show Dodona error details on 403 responses

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -19,6 +19,7 @@ import { INVALID_TOKEN_MSG, MISSING_TOKEN_MSG } from "../constants/messages";
 import { TOKEN_INSTUCTIONS_URL } from "../constants/urls";
 import { DodonaEnvironments } from "../dodonaEnvironment";
 import { logger } from "../logging/logger";
+import { extractErrorMessage } from "../util/errors";
 import { InvalidAccessToken } from "./errors/invalidAccessToken";
 import {
     ActivityManager,
@@ -185,7 +186,7 @@ export default async function execute<T>(
                     }
                 });
         } else if (error instanceof HTTPError && error.response.statusCode === 403) {
-            const errorMessage = (error.response?.body as { error?: string })?.error || "Not allowed to access this resource.";
+            const errorMessage = extractErrorMessage(error.response?.body) || "Not allowed to access this resource.";
             window.showErrorMessage(errorMessage);
         } else if (error instanceof RequestError) {
             // Attempt to fix the certificate error.

--- a/src/util/errors.test.ts
+++ b/src/util/errors.test.ts
@@ -1,0 +1,85 @@
+import * as assert from "assert";
+
+import { extractErrorMessage } from "./errors";
+
+describe("test extractErrorMessage top-level error", () => {
+    it("should return the top-level error string", () => {
+        assert.equal(
+            extractErrorMessage({ error: "not permitted" }),
+            "not permitted",
+        );
+    });
+});
+
+describe("test extractErrorMessage errors hash", () => {
+    it("should humanize and flatten a single attribute", () => {
+        assert.equal(
+            extractErrorMessage({
+                status: "failed",
+                errors: { exercise: ["not permitted"] },
+            }),
+            "Exercise not permitted",
+        );
+    });
+
+    it("should join multiple attributes and messages with '; '", () => {
+        assert.equal(
+            extractErrorMessage({
+                errors: {
+                    exercise: ["not permitted", "is archived"],
+                    submission: ["is invalid"],
+                },
+            }),
+            "Exercise not permitted; Exercise is archived; Submission is invalid",
+        );
+    });
+
+    it("should humanize an underscored attribute", () => {
+        assert.equal(
+            extractErrorMessage({
+                errors: { activity_read_state: ["invalid"] },
+            }),
+            "Activity read state invalid",
+        );
+    });
+
+    it("should return null for an empty errors object", () => {
+        assert.equal(extractErrorMessage({ errors: {} }), null);
+    });
+});
+
+describe("test extractErrorMessage invalid bodies", () => {
+    it("should return null for null", () => {
+        assert.equal(extractErrorMessage(null), null);
+    });
+
+    it("should return null for undefined", () => {
+        assert.equal(extractErrorMessage(undefined), null);
+    });
+
+    it("should return null for a plain string", () => {
+        assert.equal(extractErrorMessage("not allowed"), null);
+    });
+
+    it("should return null for an array", () => {
+        assert.equal(extractErrorMessage(["not allowed"]), null);
+    });
+
+    it("should return null when errors is not an object", () => {
+        assert.equal(extractErrorMessage({ errors: "not allowed" }), null);
+    });
+
+    it("should return null when error is an empty string", () => {
+        assert.equal(
+            extractErrorMessage({ error: "", errors: {} }),
+            null,
+        );
+    });
+
+    it("should ignore non-string messages", () => {
+        assert.equal(
+            extractErrorMessage({ errors: { exercise: [1, null, "not permitted"] } }),
+            "Exercise not permitted",
+        );
+    });
+});

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -1,0 +1,68 @@
+/**
+ * Humanizes an attribute name by replacing underscores with spaces and
+ * capitalizing the first letter.
+ *
+ * @param attribute the attribute name to humanize
+ * @return the humanized attribute name
+ */
+function humanizeAttribute(attribute: string): string {
+    const spaced = attribute.replace(/_/g, " ");
+    if (spaced.length === 0) {
+        return spaced;
+    }
+    return spaced.charAt(0).toUpperCase() + spaced.substring(1);
+}
+
+/**
+ * Extracts a human-readable error message from an API response body.
+ *
+ * Dodona denies actions with a body shaped like Rails validation errors,
+ * e.g. `{"status": "failed", "errors": {"exercise": ["not permitted"]}}`,
+ * a hash of attribute name to an array of message strings. This flattens
+ * that shape into a single string, formatted similarly to Rails'
+ * `full_messages`: "<Humanized attribute> <message>", joining multiple
+ * resulting sentences with "; ". A top-level `error` string is also
+ * supported, for compatibility with any API that sends a singular key.
+ *
+ * This function is defensive and never throws: anything that does not
+ * match one of the expected shapes results in null, leaving the caller to
+ * supply its own fallback text.
+ *
+ * @param body the response body to extract the error message from
+ * @return the extracted error message, or null if none could be extracted
+ */
+export function extractErrorMessage(body: unknown): string | null {
+    if (typeof body !== "object" || body === null || Array.isArray(body)) {
+        return null;
+    }
+
+    const { error, errors } = body as { error?: unknown; errors?: unknown };
+
+    // A top-level singular error message.
+    if (typeof error === "string" && error.length > 0) {
+        return error;
+    }
+
+    // A hash of attribute name to an array of message strings.
+    if (typeof errors !== "object" || errors === null || Array.isArray(errors)) {
+        return null;
+    }
+
+    const messages: string[] = [];
+    for (const [attribute, attributeMessages] of Object.entries(
+        errors as Record<string, unknown>,
+    )) {
+        if (!Array.isArray(attributeMessages)) {
+            continue;
+        }
+
+        const humanizedAttribute = humanizeAttribute(attribute);
+        for (const message of attributeMessages) {
+            if (typeof message === "string" && message.length > 0) {
+                messages.push(`${humanizedAttribute} ${message}`);
+            }
+        }
+    }
+
+    return messages.length > 0 ? messages.join("; ") : null;
+}


### PR DESCRIPTION
In dodona-edu/dodona#8531 Dodona switches to returning `403 Forbidden` (instead of the legacy `422`) when a user is not allowed to create a submission. The plugin's 403 handler currently reads a top-level `error` (singular) key from the response body, but Dodona's error bodies use `errors` (plural, a Rails-style hash of attribute to messages), so users always end up with the generic "Not allowed to access this resource." fallback. The full analysis lives in dodona-edu/dodona#8266.

This PR adds a small `extractErrorMessage` util that flattens that shape into something readable, similar to Rails' `full_messages`: `{"errors": {"exercise": ["not permitted"]}}` becomes "Exercise not permitted". A top-level `error` string still takes precedence, and anything unexpected (including an empty `errors: {}`) falls back to the generic message, as before. Unit tests included; lint, unit tests and build all pass locally.

**Manual testing instructions**
- Configure the plugin with a valid API token
- Try to submit to an exercise you're not allowed to submit to (e.g. in a closed series)
- The error popup should now read "Exercise not permitted" instead of the generic message

Note: this only kicks in once dodona-edu/dodona#8531 is deployed. Until then a denied submission still returns `422`, which the plugin surfaces as a raw `HTTPError` popup (unchanged by this PR).
